### PR TITLE
Enable nRST pullup (Instead default pulldown!), causing issues.

### DIFF
--- a/attack/attack.c
+++ b/attack/attack.c
@@ -82,7 +82,7 @@ int main()
 	gpio_init(RESET_PIN);
 	gpio_init(BOOT0_PIN);
 	gpio_set_dir(LED_PIN, GPIO_OUT);
-	gpio_set_dir(BOOT0_PIN, GPIO_OUT);	
+	gpio_set_dir(BOOT0_PIN, GPIO_OUT);
 	gpio_set_dir(RESET_PIN, GPIO_IN);
 	gpio_pull_up(RESET_PIN);
 

--- a/attack/attack.c
+++ b/attack/attack.c
@@ -82,8 +82,9 @@ int main()
 	gpio_init(RESET_PIN);
 	gpio_init(BOOT0_PIN);
 	gpio_set_dir(LED_PIN, GPIO_OUT);
-	gpio_set_dir(BOOT0_PIN, GPIO_OUT);
+	gpio_set_dir(BOOT0_PIN, GPIO_OUT);	
 	gpio_set_dir(RESET_PIN, GPIO_IN);
+	gpio_pull_up(RESET_PIN);
 
 	// Init PWM for indicator LED
 	gpio_set_function(LED_PIN, GPIO_FUNC_PWM);
@@ -154,7 +155,8 @@ int main()
 	// Due to the FPB, the target will now jump to
 	// stage 2 of the exploit and dump the contents
 	// of the flash over UART
-	gpio_set_dir(RESET_PIN, GPIO_IN);
+	gpio_set_dir(RESET_PIN, GPIO_IN);	
+	gpio_pull_up(RESET_PIN);
 
 	// Wait for dump start magic to ensure
 	// that we don't forward any garbage data

--- a/attack/attack.c
+++ b/attack/attack.c
@@ -155,7 +155,7 @@ int main()
 	// Due to the FPB, the target will now jump to
 	// stage 2 of the exploit and dump the contents
 	// of the flash over UART
-	gpio_set_dir(RESET_PIN, GPIO_IN);	
+	gpio_set_dir(RESET_PIN, GPIO_IN);
 	gpio_pull_up(RESET_PIN);
 
 	// Wait for dump start magic to ensure


### PR DESCRIPTION
Pico's input default setting is pulldown!
This makes a voltage divider against the nRST pullup in the STM32- I was getting 2.7V, others got 1.2V... this will cause random behaviour, might work for some and not for others.

Fix this by enabling the RESET pin pullup so it sits at 3.3V.