### PR TITLE
Detect flash size

### DIFF
--- a/target/main.c
+++ b/target/main.c
@@ -154,6 +154,13 @@ int main(void)
 #error "No USART selected"
 #endif
 
+	// Flash size register, RM0008, page 1076:
+	// https://www.st.com/resource/en/reference_manual/rm0008-stm32f101xx-stm32f102xx-stm32f103xx-stm32f105xx-and-stm32f107xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
+
+	uint32_t flash_size = *(uint32_t*)0x1FFFF7E0 & 0xFFFF;
+	if(flash_size==64)        // Force reading of the entire 128KB flash in 64KB devices, often used.
+	  flash_size=128;
+
 	/* Print start magic to inform the attack board that
 	   we are going to dump */
 	for (uint32_t i = 0; i < sizeof(DUMP_START_MAGIC); i++) {
@@ -161,7 +168,7 @@ int main(void)
 	}
 
 	uint32_t const * addr = (uint32_t*) 0x08000000;
-	while (((uintptr_t) addr) < (0x08000000 + 64u * 1024u)) {
+	while (((uintptr_t) addr) < (0x08000000U + (flash_size * 1024U) )) {
 		writeWordBe(*addr);
 		++addr;
 	}


### PR DESCRIPTION
DBGMCU_IDCODE @ 0xE0042000 ([RM0008](https://www.st.com/resource/en/reference_manual/rm0008-stm32f101xx-stm32f102xx-stm32f103xx-stm32f105xx-and-stm32f107xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) page 1088) reads 0 in the attack firmware, so we can't detect the flash using DEV_ID.
Flash size register @ 0x1FFFF7E0 ([RM0008](https://www.st.com/resource/en/reference_manual/rm0008-stm32f101xx-stm32f102xx-stm32f103xx-stm32f105xx-and-stm32f107xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) page 1076) works, so use it instead.

64KB devices actually have 128KB, it's the same die.
Some firmwares use it, specially chinese devices, as they're cheaper and work anyways.
So, override to 128KB when reporting 64KB.