### PR TITLE
Wait after detecting debugger to ensure stable connections

### DIFF
--- a/dump.py
+++ b/dump.py
@@ -225,6 +225,10 @@ def debug_probe_connected():
 def wait_dbg_probe_connect():
     while not debug_probe_connected():
         time.sleep(1)  # Wait for 1 second before retrying
+        
+    # Wait 2 seconds afterwards to ensure stable connections
+    # Otherwise, it might make a momentary connection while messing with the wires, but fail later!
+    time.sleep(2)
 
 
 # Waits until the debug probe is disconnected


### PR DESCRIPTION
As the detection delay might end anytime while connecting the wires, sometimes it would start too early, while still moving the wires, and fail.
Add a small delay to ensure everything is settled down.