### PR TITLE
Add IWDG support

### DIFF
--- a/target/main.c
+++ b/target/main.c
@@ -26,6 +26,7 @@
 
 #define __IO volatile
 
+uint8_t iwdg_enabled;
 const char DUMP_START_MAGIC[] = {0x10, 0xAD, 0xDA, 0x7A};
 
 //// Special Registers
@@ -251,7 +252,7 @@ int main(void)
 #else
 #error "No USART selected"
 #endif
-	uint8_t iwdg_enabled = OB->USER & (1UL<<16);
+	iwdg_enabled = OB->USER & (1UL<<16);
 	uint32_t flash_size = FLASH_SIZE_REG & 0xFFFF;
 	if (flash_size == 64) 				// Force reading of the entire 128KB flash in 64KB devices, often used.
 	{

--- a/target/main.c
+++ b/target/main.c
@@ -252,7 +252,7 @@ int main(void)
 #else
 #error "No USART selected"
 #endif
-	iwdg_enabled = OB->USER & (1UL<<16);
+	iwdg_enabled = (OB->USER & (1UL<<16)) == 0;	// Check WDG_SW bit. Page 20: https://www.st.com/resource/en/programming_manual/pm0075-stm32f10xxx-flash-memory-microcontrollers-stmicroelectronics.pdf
 	uint32_t flash_size = FLASH_SIZE_REG & 0xFFFF;
 	if (flash_size == 64) 				// Force reading of the entire 128KB flash in 64KB devices, often used.
 	{


### PR DESCRIPTION
Don't enable the IWDG by default, but parse the Option bytes and check if IWDG is force-enabled, then refresh the IWDG while waiting for every UART transfer.

Might fix this: https://github.com/CTXz/stm32f1-picopwner/issues/20