### PR TITLE
Implement IWDG. Ignore flash size, dump until hard fault. Show hex address.

### DIFF
--- a/dump.py
+++ b/dump.py
@@ -512,14 +512,15 @@ with open(fname, "wb") as f:
 
         f.write(data)
 
+        if read_bytes % 16 == 0:
+            print("\n" + hex(0x8000000 + read_bytes) + ": ", end="")
+            
         # Convert to hex string and print
         data = data.hex()
         print(" " + data, end="")
 
         # Beak line every 16 bytes
         read_bytes += 1
-        if read_bytes % 16 == 0:
-            print()
 
     # Check if we managed to read any data
     # If we haven't, something went wrong


### PR DESCRIPTION
Check WDG_SW in Option Bytes, IWDG might be enabled by hardware, triggering a reset while dumping the firmware and causing an endless loop.

Ignore flash size register as not all stm32 clones implement it.
Instead, dump up to 1MB, when the flash is over it'll trigger a hard fault and stop.